### PR TITLE
fix: the neo4j bytes tostring error

### DIFF
--- a/lib/src/print.c
+++ b/lib/src/print.c
@@ -336,7 +336,7 @@ ssize_t neo4j_bytes_str(const neo4j_value_t *value, char *buf, size_t n)
 
     for (unsigned int i = 0; i < v->length; ++i)
     {
-        int r = snprintf(buf + l, (l < n)? n-l : 0, "%02x", v->bytes[i]);
+        int r = snprintf(buf + l, (l < n)? n-l : 0, "%02hhx", v->bytes[i]);
         if (r < 0)
         {
             return -1;
@@ -366,7 +366,7 @@ ssize_t neo4j_bytes_fprint(const neo4j_value_t *value, FILE *stream)
     ssize_t l = 1;
     for (unsigned int i = 0; i < v->length; ++i)
     {
-        int r = fprintf(stream, "%02x", v->bytes[i]);
+        int r = fprintf(stream, "%02hhx", v->bytes[i]);
         if (r < 0)
         {
             return -1;


### PR DESCRIPTION
The neo4j bytes are stored in the "char *" type rather than the "unsigned char *" type. When it is converted into a formatted string, if the value of a single byte exceeds 0x7f, it will be formatted incorrectly.
Since modifying the interface type to `unsigned char *` would affect backward compatibility, it was decided to only modify the logic of the formatted string, limiting it to no more than 2 characters.