### PR TITLE
fix: incorrect minor version negotiated

### DIFF
--- a/lib/src/connection.c
+++ b/lib/src/connection.c
@@ -457,8 +457,8 @@ int negotiate_protocol_version(neo4j_iostream_t *iostream,
         return -1;
     }
     agreed_version = ntohl(agreed_version);
-    *protocol_version = agreed_version & 0007;
-    *protocol_minor_version = (agreed_version & 0700) >> 8;
+    *protocol_version = agreed_version & 0x0007;
+    *protocol_minor_version = (agreed_version & 0x0700) >> 8;
     return 0;
 }
 


### PR DESCRIPTION
The minor version is incorrectly masked with octal `0700`. It get the false minor version(always zero).
The true mask is to use hexadecimal `0x0700`.