### PR TITLE
Fix/transaction memory leak

### DIFF
--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -532,9 +532,10 @@ const char *neo4j_tx_commit_bookmark(neo4j_transaction_t *tx)
 void neo4j_free_tx(neo4j_transaction_t *tx)
 {
   // free bookmarks array space
-  // free tx space
   if (tx->num_bookmarks > 0) {
     neo4j_free(tx->allocator, (void *)tx->bookmarks);
   }
+  neo4j_logger_release(tx->logger);
+  // free tx space
   neo4j_free(tx->allocator, tx);
 }

--- a/lib/src/transaction.c
+++ b/lib/src/transaction.c
@@ -535,6 +535,7 @@ void neo4j_free_tx(neo4j_transaction_t *tx)
   if (tx->num_bookmarks > 0) {
     neo4j_free(tx->allocator, (void *)tx->bookmarks);
   }
+  neo4j_mpool_drain(&tx->mpool);
   neo4j_logger_release(tx->logger);
   // free tx space
   neo4j_free(tx->allocator, tx);


### PR DESCRIPTION
Fix 2 meory leak in transaction. 
1. unreleased logger.
2. undrained mpool.