### PR TITLE
fix: logger memory leak and multithread warn doc

### DIFF
--- a/lib/src/neo4j-client.h.in
+++ b/lib/src/neo4j-client.h.in
@@ -295,6 +295,14 @@ struct neo4j_logger_provider
  *
  * If no flags are required, pass 0 or `NEO4J_STD_LOGGER_DEFAULT`.
  *
+ * @warning **Thread-Safety Warning:** The logger provider instance returned by
+ * this function is **NOT thread-safe**.
+ *
+ * It is unsafe to share a single `neo4j_config_t` object containing this
+ * provider across multiple threads if those threads will be creating
+ * connections (`neo4j_connect` or `neo4j_tcp_connect`) concurrently. Doing so may
+ * lead to race conditions, memory corruption or memory leak.
+ *
  * @param [stream] The stream to output to.
  * @param [level] The default level to log at.
  * @param [flags] A bitmask of flags for the standard logger output.

--- a/lib/src/tofu.c
+++ b/lib/src/tofu.c
@@ -42,10 +42,10 @@ int neo4j_check_known_hosts(const char * restrict hostname, int port,
         const char * restrict fingerprint, const neo4j_config_t *config,
         uint_fast8_t flags)
 {
+    REQUIRE(strlen(hostname) < 256 && hostname[0] != '\0', -1);
+
     int result = -1;
     neo4j_logger_t *logger = neo4j_get_logger(config, "tofu");
-
-    REQUIRE(strlen(hostname) < 256 && hostname[0] != '\0', -1);
 
     char *buf = NULL;
     const char *file = config->known_hosts_file;


### PR DESCRIPTION
The `neo4j_check_known_hosts` used the `REQUIRE` macro after the `neo4j_get_logger`, resulting in a memory since the `REQUIRE` add a concealed return point without the `neo4j_logger_release`. The `REQUIRE` macro must be used at the beginning of a function. Meanwhile, I find that the `neo4j_std_logger_provider` is not multithread safe. This maintain the linked list and ref count without atomic or lock, which would be very prone to being misused. I think the `neo4j_std_logger_provider` is not intended to be used under a multithread scene, so I add some docs to warn user who may want to share a std logger provider among connections in different thread.